### PR TITLE
refactor: aplicar patrones arquitectónicos para desacoplar auth y mej…

### DIFF
--- a/liga1.xcodeproj/project.pbxproj
+++ b/liga1.xcodeproj/project.pbxproj
@@ -159,6 +159,13 @@
 		D0063549B126B4E82FC238DD /* UIControl+Builder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BDDF5F80F98732D353F138 /* UIControl+Builder.swift */; };
 		D1B1041D3319FD746525F468 /* AppColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916B96B6731A88F34AC09FDD /* AppColors.swift */; };
 		FF409DC8133AFDA3B8ED267E /* FormBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742E5D7ABC53132ABE23C086 /* FormBuilder.swift */; };
+		AF257A451ADC4C809BFD09A1 /* AuthServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B64C425E874DCFAAC09301 /* AuthServiceProtocol.swift */; };
+		6B89A9ABC27D4B38B28A5701 /* LogoutUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AFD27CA71B4321884C39FE /* LogoutUseCase.swift */; };
+		3DFB364AC66246E998DBC2E9 /* LoginWithEmailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB8F92B13C54890B57E2DE2 /* LoginWithEmailUseCase.swift */; };
+		A76A4167D719438AA4F4251C /* LoginWithGoogleUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143B6DFC97CF47F2AD215DF5 /* LoginWithGoogleUseCase.swift */; };
+		623A010AAFBB4DD7BF7D0D95 /* ObserveAuthStateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E109A8BC5549E49F10898A /* ObserveAuthStateUseCase.swift */; };
+		DE4689A273B24EF0A2DFD6CC /* InactivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D706A2DD87EA40468D0EDDED /* InactivityManager.swift */; };
+		DAD0218A714640C2A2D1FA8E /* CachingTeamsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694907FBF5CB4113A6E4BC61 /* CachingTeamsRepository.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -331,6 +338,13 @@
 		916B96B6731A88F34AC09FDD /* AppColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppColors.swift; sourceTree = "<group>"; };
 		B73A13053D4CC2A0297ECDD1 /* ComponentPresets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentPresets.swift; sourceTree = "<group>"; };
 		CAE86397D312558B0952F475 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
+		27B64C425E874DCFAAC09301 /* AuthServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthServiceProtocol.swift; sourceTree = "<group>"; };
+		35AFD27CA71B4321884C39FE /* LogoutUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutUseCase.swift; sourceTree = "<group>"; };
+		6FB8F92B13C54890B57E2DE2 /* LoginWithEmailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginWithEmailUseCase.swift; sourceTree = "<group>"; };
+		143B6DFC97CF47F2AD215DF5 /* LoginWithGoogleUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginWithGoogleUseCase.swift; sourceTree = "<group>"; };
+		40E109A8BC5549E49F10898A /* ObserveAuthStateUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserveAuthStateUseCase.swift; sourceTree = "<group>"; };
+		D706A2DD87EA40468D0EDDED /* InactivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactivityManager.swift; sourceTree = "<group>"; };
+		694907FBF5CB4113A6E4BC61 /* CachingTeamsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingTeamsRepository.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -382,6 +396,7 @@
 				4603CF662F42AD1900F537A4 /* AuthProviderFactory.swift */,
 				4603CF672F42AD1900F537A4 /* AuthProviderStrategy.swift */,
 				4603CF682F42AD1900F537A4 /* AuthProviderType.swift */,
+				27B64C425E874DCFAAC09301 /* AuthServiceProtocol.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -534,6 +549,7 @@
 				4640017F2F08853F00A8C905 /* MatchesRepository.swift */,
 				464001802F08853F00A8C905 /* NewsRepository.swift */,
 				464001812F08853F00A8C905 /* TeamsRepository.swift */,
+				694907FBF5CB4113A6E4BC61 /* CachingTeamsRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -560,9 +576,21 @@
 			path = Data;
 			sourceTree = "<group>";
 		};
+		87DCDBFEACCB404C835152C5 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				35AFD27CA71B4321884C39FE /* LogoutUseCase.swift */,
+				6FB8F92B13C54890B57E2DE2 /* LoginWithEmailUseCase.swift */,
+				143B6DFC97CF47F2AD215DF5 /* LoginWithGoogleUseCase.swift */,
+				40E109A8BC5549E49F10898A /* ObserveAuthStateUseCase.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
 		4640018D2F08853F00A8C905 /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
+				87DCDBFEACCB404C835152C5 /* Auth */,
 				464B95B22F287601001C4049 /* Notifications */,
 				464009C62F098D8D00A8C905 /* Favorites */,
 				464009C82F098D8D00A8C905 /* Jornadas */,
@@ -1095,6 +1123,7 @@
 				46D995922C6E90EC00D4951C /* AppDelegate.swift */,
 				469E54322E765141001ECD36 /* SessionManager.swift */,
 				46D995942C6E90EC00D4951C /* SceneDelegate.swift */,
+				D706A2DD87EA40468D0EDDED /* InactivityManager.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -1397,6 +1426,13 @@
 				46CDF4882F10623000F280E6 /* JornadaUIMapper.swift in Sources */,
 				464001E12F08853F00A8C905 /* FavoritesService.swift in Sources */,
 				46D995952C6E90EC00D4951C /* SceneDelegate.swift in Sources */,
+				AF257A451ADC4C809BFD09A1 /* AuthServiceProtocol.swift in Sources */,
+				6B89A9ABC27D4B38B28A5701 /* LogoutUseCase.swift in Sources */,
+				3DFB364AC66246E998DBC2E9 /* LoginWithEmailUseCase.swift in Sources */,
+				A76A4167D719438AA4F4251C /* LoginWithGoogleUseCase.swift in Sources */,
+				623A010AAFBB4DD7BF7D0D95 /* ObserveAuthStateUseCase.swift in Sources */,
+				DE4689A273B24EF0A2DFD6CC /* InactivityManager.swift in Sources */,
+				DAD0218A714640C2A2D1FA8E /* CachingTeamsRepository.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/liga1/Application/Coordinator/AppCoordinator.swift
+++ b/liga1/Application/Coordinator/AppCoordinator.swift
@@ -16,6 +16,8 @@ final class AppCoordinator: Coordinator {
     let window: UIWindow
     private let container: DIContainer
     private let eventBus: AppEventBusProtocol
+    private let authService: AuthServiceProtocol
+    private let logoutUseCase: LogoutUseCaseProtocol
     private let logger: LoggerProtocol
     private var cancellables = Set<AnyCancellable>()
     private var hasReceivedInitialAuthState = false
@@ -24,11 +26,15 @@ final class AppCoordinator: Coordinator {
         window: UIWindow,
         container: DIContainer,
         eventBus: AppEventBusProtocol,
+        authService: AuthServiceProtocol,
+        logoutUseCase: LogoutUseCaseProtocol,
         logger: LoggerProtocol
     ) {
         self.window = window
         self.container = container
         self.eventBus = eventBus
+        self.authService = authService
+        self.logoutUseCase = logoutUseCase
         self.logger = logger
         self.navigationController = UINavigationController()
 
@@ -37,18 +43,18 @@ final class AppCoordinator: Coordinator {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in
                 switch event {
-                case .loginSuccess:
-                    self?.handleLoginSuccess()
                 case .logoutRequested:
                     self?.handleLogoutRequested()
+                case .sessionExpired:
+                    self?.handleSessionExpired()
                 case .navigateToMatch(let matchId):
                     self?.handleNotificationTap(matchId: matchId)
                 }
             }
             .store(in: &cancellables)
 
-        // Observar cambios en el estado de autenticación
-        AuthManager.shared.observeAuthState()
+        // Observar cambios en el estado de autenticación (sin acoplar a AuthManager.shared)
+        authService.observeAuthState()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] user in
                 self?.handleAuthStateChange(user: user)
@@ -57,20 +63,16 @@ final class AppCoordinator: Coordinator {
     }
 
     private func handleAuthStateChange(user: User?) {
-        // Marcar que hemos recibido el estado inicial
         let isInitialState = !hasReceivedInitialAuthState
         hasReceivedInitialAuthState = true
 
         if user != nil {
-            // Usuario autenticado - mostrar main flow si aún no está mostrándose
             if !(window.rootViewController is MainTabBarController) {
                 logger.info(isInitialState ? "✅ Estado inicial: Usuario autenticado - navegando a Main Flow" : "✅ Usuario autenticado - navegando a Main Flow")
                 childCoordinators.removeAll()
                 showMainFlow()
             }
         } else {
-            // Firebase puede emitir nil un instante antes de restaurar la sesión en frío.
-            // Diferir la decisión de login evita un flash de Login → Main al abrir la app.
             if isInitialState {
                 DispatchQueue.main.async { [weak self] in
                     self?.attemptShowLoginIfStillLoggedOut()
@@ -81,34 +83,47 @@ final class AppCoordinator: Coordinator {
         }
     }
 
-    /// Solo muestra login si `currentUser` sigue siendo nil y no estamos ya en el nav de login.
     private func attemptShowLoginIfStillLoggedOut() {
-        guard AuthManager.shared.currentUserId == nil else { return }
-        if window.rootViewController is UINavigationController {
-            return
-        }
+        guard authService.currentUserId == nil else { return }
+        if window.rootViewController is UINavigationController { return }
         logger.info("ℹ️ No hay usuario autenticado - navegando a Login Flow")
         childCoordinators.removeAll()
         showLoginFlow()
     }
 
-    private func handleLoginSuccess() {
-        // Este método ahora es manejado principalmente por observeAuthState
-        // Pero lo mantenemos para limpieza de coordinadores
-        childCoordinators.removeAll()
-        logger.info("📱 Login exitoso recibido via EventBus")
-    }
-
     private func handleLogoutRequested() {
-        // Este método ya no navega directamente - el observeAuthState se encarga
-        // Solo limpiamos los coordinadores
         childCoordinators.removeAll()
         logger.info("📱 Logout solicitado - la navegación será manejada por observeAuthState")
     }
 
+    private func handleSessionExpired() {
+        logger.info("⏰ Sesión expirada por inactividad - ejecutando logout")
+        logoutUseCase.execute()
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { [weak self] completion in
+                    if case .failure(let error) = completion {
+                        self?.logger.error("❌ Error al cerrar sesión por inactividad", error: error)
+                    }
+                    self?.showSessionExpiredAlert()
+                },
+                receiveValue: { }
+            )
+            .store(in: &cancellables)
+    }
+
+    private func showSessionExpiredAlert() {
+        guard let rootVC = window.rootViewController else { return }
+        let alert = UIAlertController(
+            title: "Sesión Expirada",
+            message: "Tu sesión ha terminado por inactividad.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Aceptar", style: .default))
+        rootVC.present(alert, animated: true)
+    }
+
     func start() {
-        // Mostrar una pantalla de carga mientras esperamos el estado de autenticación
-        // El observeAuthState() navegará a login o main según corresponda
         showLoadingScreen()
         logger.info("🚀 AppCoordinator iniciado - esperando estado de autenticación")
     }
@@ -117,7 +132,6 @@ final class AppCoordinator: Coordinator {
         let loadingVC = UIViewController()
         loadingVC.view.backgroundColor = .appBackground
 
-        // Agregar activity indicator
         let activityIndicator = UIActivityIndicatorView(style: .large)
         activityIndicator.color = .liga1Red
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
@@ -149,7 +163,6 @@ final class AppCoordinator: Coordinator {
         window.makeKeyAndVisible()
     }
 
-    /// Navegación al abrir la app desde un tap en notificación push (matchId).
     func handleNotificationTap(matchId: String) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self,
@@ -159,7 +172,7 @@ final class AppCoordinator: Coordinator {
     }
 }
 
-// MARK: - LoginCoordinatorDelegate (compatibilidad; la lógica principal va por EventBus .loginSuccess)
+// MARK: - LoginCoordinatorDelegate
 
 extension AppCoordinator: LoginCoordinatorDelegate {
     func loginCoordinatorDidFinish(_ coordinator: LoginCoordinator) {

--- a/liga1/Application/Coordinator/LoginCoordinator.swift
+++ b/liga1/Application/Coordinator/LoginCoordinator.swift
@@ -32,7 +32,6 @@ final class LoginCoordinator: Coordinator {
     }
 
     func didFinishLogin() {
-        eventBus.publish(.loginSuccess)
         delegate?.loginCoordinatorDidFinish(self)
     }
 }

--- a/liga1/Application/Events/AppEvent.swift
+++ b/liga1/Application/Events/AppEvent.swift
@@ -7,9 +7,10 @@
 
 import Foundation
 
-/// Eventos de aplicación para el bus (login, logout, navegación).
+/// Eventos de aplicación para el bus (logout, sesión, navegación).
+/// Nota: loginSuccess fue eliminado — AppCoordinator observa AuthServiceProtocol directamente.
 enum AppEvent {
-    case loginSuccess
     case logoutRequested
+    case sessionExpired
     case navigateToMatch(matchId: String)
 }

--- a/liga1/Application/InactivityManager.swift
+++ b/liga1/Application/InactivityManager.swift
@@ -1,0 +1,33 @@
+//
+//  InactivityManager.swift
+//  liga1
+//
+//  Application: Detecta inactividad del usuario y publica .sessionExpired al EventBus.
+//  SRP: solo maneja el timer — auth y navegación quedan en AppCoordinator.
+//
+
+import Foundation
+
+final class InactivityManager {
+
+    private let eventBus: AppEventBusProtocol
+    private let timeout: TimeInterval
+    private var timer: Timer?
+
+    init(eventBus: AppEventBusProtocol, timeout: TimeInterval = 432_000) {
+        self.eventBus = eventBus
+        self.timeout = timeout
+    }
+
+    func reset() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { [weak self] _ in
+            self?.eventBus.publish(.sessionExpired)
+        }
+    }
+
+    func invalidate() {
+        timer?.invalidate()
+        timer = nil
+    }
+}

--- a/liga1/Application/SceneDelegate.swift
+++ b/liga1/Application/SceneDelegate.swift
@@ -32,8 +32,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Crear DIContainer
         let container = DIContainer.shared
 
-        // Configurar SessionManager
-        SessionManager.shared.configure(with: window, container: container)
+        // Configurar SessionManager con el EventBus (InactivityManager vive dentro)
+        let eventBus = container.makeAppEventBus()
+        SessionManager.shared.configure(eventBus: eventBus)
 
         // Iniciar AppCoordinator
         let appCoordinator = container.makeAppCoordinator(window: window)
@@ -41,7 +42,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         appCoordinator.start() // AppCoordinator maneja window.makeKeyAndVisible()
 
         // Tap en notificación → EventBus → AppCoordinator maneja .navigateToMatch
-        let eventBus = container.makeAppEventBus()
         SessionManager.shared.onNotificationTap = { matchId in
             eventBus.publish(.navigateToMatch(matchId: matchId))
         }

--- a/liga1/Application/SessionManager.swift
+++ b/liga1/Application/SessionManager.swift
@@ -4,87 +4,39 @@
 //
 //  Created by miguel tomairo on 13/09/25.
 //
+//  Responsabilidad actual: bridge para notificaciones push y configuración de InactivityManager.
+//  Auth y navegación por expiración de sesión se delegan a AppCoordinator via InactivityManager.
+//
 
 import UIKit
-import Combine
 
 final class SessionManager {
 
     static let shared = SessionManager()
     private init() {}
 
-    private var inactivityTimer: Timer?
-    private let inactivityTimeLimit: TimeInterval = 432000 // 5 días (5 * 24 * 60 * 60)
-
-    weak var window: UIWindow?
-    private var container: DIContainer?
-    private var cancellables = Set<AnyCancellable>()
+    private var inactivityManager: InactivityManager?
 
     /// Se invoca cuando el usuario toca una notificación push (matchId).
     var onNotificationTap: ((String) -> Void)?
 
-    // MARK: - Configuración inicial
-    func configure(with window: UIWindow?, container: DIContainer) {
-        self.window = window
-        self.container = container
+    // MARK: - Configuración
+
+    func configure(eventBus: AppEventBusProtocol) {
+        inactivityManager = InactivityManager(eventBus: eventBus)
     }
 
     // MARK: - Inactividad
+
     func startInactivityTimer() {
-        resetTimer()
+        inactivityManager?.reset()
     }
 
     func resetTimer() {
-        inactivityTimer?.invalidate()
-        inactivityTimer = Timer.scheduledTimer(timeInterval: inactivityTimeLimit,
-                                               target: self,
-                                               selector: #selector(showSessionExpiredAlert),
-                                               userInfo: nil,
-                                               repeats: false)
+        inactivityManager?.reset()
     }
 
-    // MARK: - Logout
-    func logout() {
-        guard let container = container else {
-            DIContainer.shared.makeLogger().error("❌ SessionManager: Container no configurado", error: nil)
-            return
-        }
-        let logger = container.makeLogger()
-
-        AuthManager.shared.logout()
-            .receive(on: DispatchQueue.main)
-            .sink(
-                receiveCompletion: { [weak self] completion in
-                    if case .failure(let error) = completion {
-                        logger.error("❌ Error al cerrar sesión", error: error)
-                    }
-                    self?.navigateToLogin()
-                },
-                receiveValue: { }
-            )
-            .store(in: &cancellables)
-    }
-
-    private func navigateToLogin() {
-        guard let container = container else { return }
-        let nav = UINavigationController()
-        let loginVC = container.makeLoginViewController(presentingViewController: nav)
-        nav.setViewControllers([loginVC], animated: false)
-        window?.rootViewController = nav
-    }
-
-    // MARK: - Alerta de expiración
-    @objc private func showSessionExpiredAlert() {
-        logout()
-
-        guard let rootVC = window?.rootViewController else { return }
-
-        let alert = UIAlertController(title: "Sesión Expirada",
-                                      message: "Tu sesión ha terminado por inactividad.",
-                                      preferredStyle: .alert)
-
-        alert.addAction(UIAlertAction(title: "Aceptar", style: .default))
-
-        rootVC.present(alert, animated: true)
+    func stopTimer() {
+        inactivityManager?.invalidate()
     }
 }

--- a/liga1/AuthKit/Core/AuthManager.swift
+++ b/liga1/AuthKit/Core/AuthManager.swift
@@ -88,6 +88,10 @@ public final class AuthManager {
     }
 }
 
+// MARK: - AuthServiceProtocol Conformance
+
+extension AuthManager: AuthServiceProtocol {}
+
 // MARK: - Auth Errors
 
 /// Errores específicos de AuthKit

--- a/liga1/AuthKit/Core/AuthServiceProtocol.swift
+++ b/liga1/AuthKit/Core/AuthServiceProtocol.swift
@@ -1,0 +1,30 @@
+//
+//  AuthServiceProtocol.swift
+//  liga1
+//
+//  AuthKit/Core: Protocolo público del servicio de autenticación.
+//  Permite inyectar AuthManager como dependencia en lugar de acceder al singleton directamente.
+//
+
+import Foundation
+import Combine
+
+/// Contrato público del servicio de autenticación.
+/// AuthManager conforma este protocolo — los callers dependen de esta abstracción, no del concreto.
+public protocol AuthServiceProtocol: AnyObject {
+
+    /// ID del usuario actualmente autenticado (nil si no hay sesión)
+    var currentUserId: String? { get }
+
+    /// Inicia sesión con email y contraseña
+    func login(email: String, password: String) -> AnyPublisher<User, Error>
+
+    /// Inicia sesión con credenciales de Google
+    func signInWithGoogle(credential: GoogleCredential) -> AnyPublisher<User, Error>
+
+    /// Cierra la sesión actual
+    func logout() -> AnyPublisher<Void, Error>
+
+    /// Observa cambios en el estado de autenticación
+    func observeAuthState() -> AnyPublisher<User?, Never>
+}

--- a/liga1/AuthKit/Presentation/ViewModels/LoginViewModel.swift
+++ b/liga1/AuthKit/Presentation/ViewModels/LoginViewModel.swift
@@ -3,7 +3,6 @@
 //  liga1
 //
 //  AuthKit/Presentation: ViewModel del flujo de login.
-//  Refactored on 15/02/26 to use AuthManager instead of LoginUseCase.
 //
 
 import Foundation
@@ -35,6 +34,7 @@ final class LoginViewModel {
 
     // MARK: - Dependencies
 
+    private let authService: AuthServiceProtocol
     private let logger: LoggerProtocol
 
     // MARK: - Private Properties
@@ -43,14 +43,14 @@ final class LoginViewModel {
 
     // MARK: - Initialization
 
-    init(logger: LoggerProtocol) {
+    init(authService: AuthServiceProtocol, logger: LoggerProtocol) {
+        self.authService = authService
         self.logger = logger
     }
 
     // MARK: - Methods
 
     func login(email: String, password: String) {
-        // Validar con LoginValidator
         do {
             try LoginValidator.validate(email: email, password: password)
         } catch {
@@ -61,8 +61,7 @@ final class LoginViewModel {
         isLoading = true
         error = nil
 
-        // Llamar directamente a AuthManager
-        AuthManager.shared.login(email: email, password: password)
+        authService.login(email: email, password: password)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completion in
                 self?.isLoading = false
@@ -93,13 +92,11 @@ final class LoginViewModel {
         isLoading = true
         error = nil
 
-        // Obtener credencial de Google
         let credentialProvider = GoogleCredentialProviderImpl(presentingViewController: presentingViewController)
 
         credentialProvider.provideCredential()
-            .flatMap { credential in
-                // Autenticar con AuthManager usando la credencial de Google
-                AuthManager.shared.signInWithGoogle(credential: credential)
+            .flatMap { [authService] credential in
+                authService.signInWithGoogle(credential: credential)
             }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completion in

--- a/liga1/DI/DIContainer.swift
+++ b/liga1/DI/DIContainer.swift
@@ -24,6 +24,12 @@ final class DIContainer {
         return FirestoreManager.shared
     }
 
+    // MARK: - Auth
+
+    func makeAuthService() -> AuthServiceProtocol {
+        return AuthManager.shared
+    }
+
     // MARK: - Repositories
 
     func makeJornadasRepository() -> JornadasRepositoryProtocol {
@@ -34,8 +40,12 @@ final class DIContainer {
         return MatchesRepository(database: makeDatabase(), logger: makeLogger())
     }
 
+    private lazy var teamsRepository: TeamsRepositoryProtocol = {
+        return CachingTeamsRepository(wrapping: TeamsRepository(database: makeDatabase()))
+    }()
+
     func makeTeamsRepository() -> TeamsRepositoryProtocol {
-        return TeamsRepository(database: makeDatabase())
+        return teamsRepository
     }
 
     func makeNewsRepository() -> NewsRepositoryProtocol {
@@ -44,10 +54,8 @@ final class DIContainer {
 
     // MARK: - Services
 
-    // MARK: - Services
-
     private lazy var favoritesService: FavoritesServiceProtocol = {
-        return FavoritesService(database: makeDatabase(), logger: makeLogger())
+        return FavoritesService(database: makeDatabase(), logger: makeLogger(), authService: makeAuthService())
     }()
 
     func makeFavoritesService() -> FavoritesServiceProtocol {
@@ -65,7 +73,8 @@ final class DIContainer {
     private lazy var userPreferencesService: UserPreferencesServiceProtocol = {
         return UserPreferencesService(
             database: makeDatabase(),
-            logger: makeLogger()
+            logger: makeLogger(),
+            authService: makeAuthService()
         )
     }()
 
@@ -179,8 +188,22 @@ final class DIContainer {
     }
 
     // MARK: - Use Cases - Auth
-    // AuthKit ahora se usa directamente vía AuthManager.shared
-    // No se necesitan UseCases separados
+
+    func makeLoginWithEmailUseCase() -> LoginWithEmailUseCaseProtocol {
+        return LoginWithEmailUseCase(authService: makeAuthService())
+    }
+
+    func makeLoginWithGoogleUseCase() -> LoginWithGoogleUseCaseProtocol {
+        return LoginWithGoogleUseCase(authService: makeAuthService())
+    }
+
+    func makeObserveAuthStateUseCase() -> ObserveAuthStateUseCaseProtocol {
+        return ObserveAuthStateUseCase(authService: makeAuthService())
+    }
+
+    func makeLogoutUseCase() -> LogoutUseCaseProtocol {
+        return LogoutUseCase(authService: makeAuthService())
+    }
 
     // MARK: - Use Cases - Notifications
 
@@ -229,11 +252,15 @@ final class DIContainer {
     }
 
     func makeProfileViewModel() -> ProfileViewModel {
-        return ProfileViewModel()
+        return ProfileViewModel(
+            authService: makeAuthService(),
+            logoutUseCase: makeLogoutUseCase()
+        )
     }
 
     func makeLoginViewModel() -> LoginViewModel {
         return LoginViewModel(
+            authService: makeAuthService(),
             logger: makeLogger()
         )
     }
@@ -298,6 +325,8 @@ final class DIContainer {
             window: window,
             container: self,
             eventBus: makeAppEventBus(),
+            authService: makeAuthService(),
+            logoutUseCase: makeLogoutUseCase(),
             logger: makeLogger()
         )
     }

--- a/liga1/Data/Repositories/CachingTeamsRepository.swift
+++ b/liga1/Data/Repositories/CachingTeamsRepository.swift
@@ -1,0 +1,50 @@
+//
+//  CachingTeamsRepository.swift
+//  liga1
+//
+//  Data/Repositories: Decorator Pattern sobre TeamsRepositoryProtocol.
+//  Añade caché en memoria por TorneoType; transparente para cualquier caller.
+//
+
+import Foundation
+import Combine
+
+final class CachingTeamsRepository: TeamsRepositoryProtocol {
+
+    private let inner: TeamsRepositoryProtocol
+    private var cache: [TorneoType: [Team]] = [:]
+    private let lock = NSLock()
+
+    init(wrapping inner: TeamsRepositoryProtocol) {
+        self.inner = inner
+    }
+
+    func fetchTeams(for torneo: TorneoType) -> AnyPublisher<[Team], Error> {
+        lock.lock()
+        if let cached = cache[torneo] {
+            lock.unlock()
+            return Just(cached)
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+        lock.unlock()
+
+        return inner.fetchTeams(for: torneo)
+            .handleEvents(receiveOutput: { [weak self] teams in
+                self?.lock.lock()
+                self?.cache[torneo] = teams
+                self?.lock.unlock()
+            })
+            .eraseToAnyPublisher()
+    }
+
+    func invalidateCache(for torneo: TorneoType?) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let torneo = torneo {
+            cache.removeValue(forKey: torneo)
+        } else {
+            cache.removeAll()
+        }
+    }
+}

--- a/liga1/Data/Repositories/TeamsRepository.swift
+++ b/liga1/Data/Repositories/TeamsRepository.swift
@@ -55,6 +55,10 @@ class TeamsRepository: TeamsRepositoryProtocol {
         .eraseToAnyPublisher()
     }
 
+    func invalidateCache(for torneo: TorneoType?) {
+        // La caché del SDK de Firestore se gestiona internamente; no hay estado en memoria aquí.
+    }
+
     private func buildTeams(from documents: [QueryDocumentSnapshot]) -> [Team] {
         let teamDTOs = documents.compactMap { doc -> TeamDTO? in
             guard let dto = try? doc.data(as: TeamDTO.self) else { return nil }

--- a/liga1/Data/Services/FavoritesService.swift
+++ b/liga1/Data/Services/FavoritesService.swift
@@ -31,11 +31,14 @@ class FavoritesService: FavoritesServiceProtocol {
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(database: DatabaseProtocol, logger: LoggerProtocol) {
+    private let authService: AuthServiceProtocol
+
+    init(database: DatabaseProtocol, logger: LoggerProtocol, authService: AuthServiceProtocol) {
         self.database = database
         self.logger = logger
+        self.authService = authService
 
-        AuthManager.shared.observeAuthState()
+        authService.observeAuthState()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] user in
                 guard let self = self else { return }
@@ -49,7 +52,7 @@ class FavoritesService: FavoritesServiceProtocol {
     }
 
     private func getUserId() -> String? {
-        return AuthManager.shared.currentUserId
+        return authService.currentUserId
     }
 
     func fetchFavoriteTeams() -> AnyPublisher<Void, Error> {

--- a/liga1/Data/Services/UserPreferencesService.swift
+++ b/liga1/Data/Services/UserPreferencesService.swift
@@ -30,12 +30,14 @@ class UserPreferencesService: UserPreferencesServiceProtocol {
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(database: DatabaseProtocol, logger: LoggerProtocol) {
+    private let authService: AuthServiceProtocol
+
+    init(database: DatabaseProtocol, logger: LoggerProtocol, authService: AuthServiceProtocol) {
         self.database = database
         self.logger = logger
+        self.authService = authService
 
-        // Observar cambios de autenticación con AuthManager
-        AuthManager.shared.observeAuthState()
+        authService.observeAuthState()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] user in
                 if user != nil {
@@ -50,7 +52,7 @@ class UserPreferencesService: UserPreferencesServiceProtocol {
     // MARK: - Private Helpers
 
     private func getUserId() -> String? {
-        return AuthManager.shared.currentUserId
+        return authService.currentUserId
     }
 
     private func getPreferencesDocumentRef() -> DocumentReference? {

--- a/liga1/Domain/Repositories/TeamsRepositoryProtocol.swift
+++ b/liga1/Domain/Repositories/TeamsRepositoryProtocol.swift
@@ -11,4 +11,6 @@ import Combine
 /// Protocolo para obtener equipos
 protocol TeamsRepositoryProtocol {
     func fetchTeams(for torneo: TorneoType) -> AnyPublisher<[Team], Error>
+    /// Invalida la caché en memoria para el torneo indicado (nil = todos).
+    func invalidateCache(for torneo: TorneoType?)
 }

--- a/liga1/Domain/UseCases/Auth/LoginWithEmailUseCase.swift
+++ b/liga1/Domain/UseCases/Auth/LoginWithEmailUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  LoginWithEmailUseCase.swift
+//  liga1
+//
+//  Domain/UseCases/Auth: Orquesta validación + autenticación por email.
+//
+
+import Foundation
+import Combine
+
+protocol LoginWithEmailUseCaseProtocol {
+    func execute(email: String, password: String) -> AnyPublisher<User, Error>
+}
+
+final class LoginWithEmailUseCase: LoginWithEmailUseCaseProtocol {
+
+    private let authService: AuthServiceProtocol
+
+    init(authService: AuthServiceProtocol) {
+        self.authService = authService
+    }
+
+    func execute(email: String, password: String) -> AnyPublisher<User, Error> {
+        do {
+            try LoginValidator.validate(email: email, password: password)
+        } catch {
+            return Fail(error: error).eraseToAnyPublisher()
+        }
+        return authService.login(email: email, password: password)
+    }
+}

--- a/liga1/Domain/UseCases/Auth/LoginWithGoogleUseCase.swift
+++ b/liga1/Domain/UseCases/Auth/LoginWithGoogleUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  LoginWithGoogleUseCase.swift
+//  liga1
+//
+//  Domain/UseCases/Auth: Orquesta obtención de credencial Google + autenticación.
+//
+
+import Foundation
+import Combine
+
+protocol LoginWithGoogleUseCaseProtocol {
+    func execute(credentialProvider: GoogleCredentialProvider) -> AnyPublisher<User, Error>
+}
+
+final class LoginWithGoogleUseCase: LoginWithGoogleUseCaseProtocol {
+
+    private let authService: AuthServiceProtocol
+
+    init(authService: AuthServiceProtocol) {
+        self.authService = authService
+    }
+
+    func execute(credentialProvider: GoogleCredentialProvider) -> AnyPublisher<User, Error> {
+        credentialProvider.provideCredential()
+            .flatMap { [authService] credential in
+                authService.signInWithGoogle(credential: credential)
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/liga1/Domain/UseCases/Auth/LogoutUseCase.swift
+++ b/liga1/Domain/UseCases/Auth/LogoutUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  LogoutUseCase.swift
+//  liga1
+//
+//  Domain/UseCases/Auth: Autoridad única para cerrar sesión.
+//
+
+import Foundation
+import Combine
+
+protocol LogoutUseCaseProtocol {
+    func execute() -> AnyPublisher<Void, Error>
+}
+
+final class LogoutUseCase: LogoutUseCaseProtocol {
+
+    private let authService: AuthServiceProtocol
+
+    init(authService: AuthServiceProtocol) {
+        self.authService = authService
+    }
+
+    func execute() -> AnyPublisher<Void, Error> {
+        authService.logout()
+    }
+}

--- a/liga1/Domain/UseCases/Auth/ObserveAuthStateUseCase.swift
+++ b/liga1/Domain/UseCases/Auth/ObserveAuthStateUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  ObserveAuthStateUseCase.swift
+//  liga1
+//
+//  Domain/UseCases/Auth: Observa cambios en el estado de autenticación.
+//
+
+import Foundation
+import Combine
+
+protocol ObserveAuthStateUseCaseProtocol {
+    func execute() -> AnyPublisher<User?, Never>
+}
+
+final class ObserveAuthStateUseCase: ObserveAuthStateUseCaseProtocol {
+
+    private let authService: AuthServiceProtocol
+
+    init(authService: AuthServiceProtocol) {
+        self.authService = authService
+    }
+
+    func execute() -> AnyPublisher<User?, Never> {
+        authService.observeAuthState()
+    }
+}

--- a/liga1/Domain/UseCases/Teams/FetchTeamsUseCase.swift
+++ b/liga1/Domain/UseCases/Teams/FetchTeamsUseCase.swift
@@ -11,6 +11,7 @@ import Combine
 /// Use Case para obtener equipos de un torneo
 protocol FetchTeamsUseCaseProtocol {
     func execute(for torneo: TorneoType) -> AnyPublisher<[Team], Error>
+    func invalidateCache(for torneo: TorneoType?)
 }
 
 class FetchTeamsUseCase: FetchTeamsUseCaseProtocol {
@@ -22,7 +23,6 @@ class FetchTeamsUseCase: FetchTeamsUseCaseProtocol {
     }
 
     func execute(for torneo: TorneoType) -> AnyPublisher<[Team], Error> {
-        // Validar que no sea acumulado
         if torneo == .acumulado {
             return Fail(error: NSError(
                 domain: "FetchTeamsUseCase",
@@ -30,8 +30,11 @@ class FetchTeamsUseCase: FetchTeamsUseCaseProtocol {
                 userInfo: [NSLocalizedDescriptionKey: "Cannot fetch 'acumulado' directly. Use apertura or clausura."]
             )).eraseToAnyPublisher()
         }
-
         return repository.fetchTeams(for: torneo)
             .eraseToAnyPublisher()
+    }
+
+    func invalidateCache(for torneo: TorneoType?) {
+        repository.invalidateCache(for: torneo)
     }
 }

--- a/liga1/Presentation/ViewModels/ProfileViewModel.swift
+++ b/liga1/Presentation/ViewModels/ProfileViewModel.swift
@@ -3,7 +3,6 @@
 //  liga1
 //
 //  Created by miguel tomairo on 02/01/26.
-//  Refactored on 15/02/26 to use AuthManager instead of LogoutUseCase.
 //
 
 import Foundation
@@ -25,13 +24,20 @@ class ProfileViewModel {
     @Published private(set) var photoURL: String?
     @Published private(set) var profileImageData: Data?
 
+    // MARK: - Dependencies
+
+    private let authService: AuthServiceProtocol
+    private let logoutUseCase: LogoutUseCaseProtocol
+
     // MARK: - Private Properties
 
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Initialization
 
-    init() {
+    init(authService: AuthServiceProtocol, logoutUseCase: LogoutUseCaseProtocol) {
+        self.authService = authService
+        self.logoutUseCase = logoutUseCase
         setupSections()
         observeAuthState()
     }
@@ -42,8 +48,7 @@ class ProfileViewModel {
         isLoading = true
         error = nil
 
-        // Llamar directamente a AuthManager
-        AuthManager.shared.logout()
+        logoutUseCase.execute()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completion in
                 self?.isLoading = false
@@ -59,8 +64,8 @@ class ProfileViewModel {
     // MARK: - Private Methods
 
     private func observeAuthState() {
-        AuthManager.shared.observeAuthState()
-            .compactMap { $0 } // Solo cuando hay usuario
+        authService.observeAuthState()
+            .compactMap { $0 }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] user in
                 self?.updateUserInfo(from: user)
@@ -69,32 +74,22 @@ class ProfileViewModel {
     }
 
     private func updateUserInfo(from user: User) {
-        // Actualizar display name
-        self.displayName = user.displayName ?? "Usuario"
+        displayName = user.displayName ?? "Usuario"
+        email = user.email ?? ""
+        photoURL = user.photoURL
 
-        // Actualizar email
-        self.email = user.email ?? ""
-
-        // Actualizar photo URL
-        self.photoURL = user.photoURL
-
-        // Descargar imagen de perfil si existe
         if let photoURLString = user.photoURL,
            let url = URL(string: photoURLString) {
             downloadProfileImage(from: url)
         } else {
-            // Usar imagen por defecto
-            self.profileImageData = nil
+            profileImageData = nil
         }
     }
 
     private func downloadProfileImage(from url: URL) {
-        URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
-            if let data = data, error == nil {
-                DispatchQueue.main.async {
-                    self?.profileImageData = data
-                }
-            }
+        URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
+            guard let data = data, error == nil else { return }
+            DispatchQueue.main.async { self?.profileImageData = data }
         }.resume()
     }
 

--- a/liga1/Presentation/ViewModels/TorneoViewModel.swift
+++ b/liga1/Presentation/ViewModels/TorneoViewModel.swift
@@ -25,9 +25,6 @@ class TorneoViewModel {
     // MARK: - Private Properties
 
     private var cancellables = Set<AnyCancellable>()
-    private var cachedApertura: [TeamUI] = []
-    private var cachedClausura: [TeamUI] = []
-    private var cachedAcumulado: [TeamUI] = []
 
     // MARK: - Initialization
 
@@ -39,48 +36,22 @@ class TorneoViewModel {
 
     func loadTeams(for torneo: TorneoType) {
         selectedTorneo = torneo
-
-        switch torneo {
-        case .apertura:
-            if !cachedApertura.isEmpty {
-                displayedTeams = cachedApertura
-            } else {
-                fetchTeams(for: torneo)
-            }
-
-        case .clausura:
-            if !cachedClausura.isEmpty {
-                displayedTeams = cachedClausura
-            } else {
-                fetchTeams(for: torneo)
-            }
-
-        case .acumulado:
-            if !cachedAcumulado.isEmpty {
-                displayedTeams = cachedAcumulado
-            } else {
-                fetchAcumulado()
-            }
+        if torneo == .acumulado {
+            fetchAcumulado()
+        } else {
+            fetchTeams(for: torneo)
         }
     }
-    
-    /// Fuerza la recarga de los equipos sin usar caché
+
+    /// Fuerza recarga ignorando la caché en memoria
     func reloadTeams(for torneo: TorneoType) {
         selectedTorneo = torneo
-        
-        switch torneo {
-        case .apertura:
-            cachedApertura = [] // Limpiar caché
-            fetchTeams(for: torneo)
-        case .clausura:
-            cachedClausura = [] // Limpiar caché
-            fetchTeams(for: torneo)
-        case .acumulado:
-            cachedAcumulado = [] // Limpiar caché
-            cachedApertura = [] // También limpiar los cachés de apertura y clausura
-            cachedClausura = []
-            fetchAcumulado()
+        if torneo == .acumulado {
+            fetchTeamsUseCase.invalidateCache(for: nil)
+        } else {
+            fetchTeamsUseCase.invalidateCache(for: torneo)
         }
+        loadTeams(for: torneo)
     }
 
     // MARK: - Private Methods
@@ -97,17 +68,7 @@ class TorneoViewModel {
                     self?.error = error
                 }
             } receiveValue: { [weak self] teams in
-                guard let self = self else { return }
-                let teamsUI = TeamUIMapper.toUI(from: teams)
-                self.displayedTeams = teamsUI
-                switch torneo {
-                case .apertura:
-                    self.cachedApertura = teamsUI
-                case .clausura:
-                    self.cachedClausura = teamsUI
-                case .acumulado:
-                    break
-                }
+                self?.displayedTeams = TeamUIMapper.toUI(from: teams)
             }
             .store(in: &cancellables)
     }
@@ -130,16 +91,12 @@ class TorneoViewModel {
                 guard let self = self else { return }
 
                 var teamsDict: [String: Team] = [:]
-
-                for team in aperturaTeams {
-                    teamsDict[team.nombre] = team
-                }
-
+                for team in aperturaTeams { teamsDict[team.nombre] = team }
                 for team in clausuraTeams {
                     if let existing = teamsDict[team.nombre] {
                         let gf = existing.golesFavor + team.golesFavor
                         let gc = existing.golesContra + team.golesContra
-                        let combined = Team(
+                        teamsDict[team.nombre] = Team(
                             nombre: existing.nombre,
                             ciudad: existing.ciudad,
                             estadio: existing.estadio,
@@ -153,30 +110,19 @@ class TorneoViewModel {
                             diferenciaGoles: gf - gc,
                             puntos: existing.puntos + team.puntos
                         )
-                        teamsDict[team.nombre] = combined
                     } else {
                         teamsDict[team.nombre] = team
                     }
                 }
 
-                let acumuladoTeamsArray = Array(teamsDict.values)
-                
-                // Si todos los equipos tienen 0 puntos, ordenar alfabéticamente
-                let allHaveZeroPoints = acumuladoTeamsArray.allSatisfy { $0.puntos == 0 }
-                
-                let acumuladoTeams: [Team]
-                if allHaveZeroPoints {
-                    // Ordenar alfabéticamente por nombre
-                    acumuladoTeams = acumuladoTeamsArray.sorted {
-                        $0.nombre.localizedCaseInsensitiveCompare($1.nombre) == .orderedAscending
-                    }
+                let merged = Array(teamsDict.values)
+                let sorted: [Team]
+                if merged.allSatisfy({ $0.puntos == 0 }) {
+                    sorted = merged.sorted { $0.nombre.localizedCaseInsensitiveCompare($1.nombre) == .orderedAscending }
                 } else {
-                    acumuladoTeams = acumuladoTeamsArray.sorted { Team.isOrderedAboveInStandings($0, $1) }
+                    sorted = merged.sorted { Team.isOrderedAboveInStandings($0, $1) }
                 }
-
-                let acumuladoTeamsUI = TeamUIMapper.toUI(from: acumuladoTeams)
-                self.cachedAcumulado = acumuladoTeamsUI
-                self.displayedTeams = acumuladoTeamsUI
+                self.displayedTeams = TeamUIMapper.toUI(from: sorted)
             }
             .store(in: &cancellables)
     }

--- a/liga1Tests/Helpers/EntityFixtures.swift
+++ b/liga1Tests/Helpers/EntityFixtures.swift
@@ -82,6 +82,24 @@ extension UserPreferences {
     }
 }
 
+// MARK: - User fixtures
+
+extension User {
+    static func fixture(
+        id: String = "user-123",
+        email: String? = "test@liga1.pe",
+        displayName: String? = "Test User"
+    ) -> User {
+        User(
+            id: id,
+            email: email,
+            displayName: displayName,
+            photoURL: nil,
+            isEmailVerified: true
+        )
+    }
+}
+
 // MARK: - Test errors
 
 enum TestError: Error, Equatable {

--- a/liga1Tests/Mocks/MockAuthService.swift
+++ b/liga1Tests/Mocks/MockAuthService.swift
@@ -1,0 +1,60 @@
+// MockAuthService.swift
+// liga1Tests
+
+import Combine
+import Foundation
+@testable import liga1
+
+final class MockAuthService: AuthServiceProtocol {
+
+    // MARK: - Stubbable results
+
+    var loginResult: Result<User, Error> = .success(.fixture())
+    var signInWithGoogleResult: Result<User, Error> = .success(.fixture())
+    var logoutResult: Result<Void, Error> = .success(())
+
+    // MARK: - Call tracking
+
+    var loginCallCount = 0
+    var signInWithGoogleCallCount = 0
+    var logoutCallCount = 0
+    var observeAuthStateCallCount = 0
+    var lastLoginEmail: String?
+    var lastLoginPassword: String?
+
+    // MARK: - Observable auth state
+
+    private let authStateSubject = CurrentValueSubject<User?, Never>(nil)
+
+    var currentUserId: String? { authStateSubject.value?.id }
+
+    // MARK: - AuthServiceProtocol
+
+    func login(email: String, password: String) -> AnyPublisher<User, Error> {
+        loginCallCount += 1
+        lastLoginEmail = email
+        lastLoginPassword = password
+        return loginResult.publisher.eraseToAnyPublisher()
+    }
+
+    func signInWithGoogle(credential: GoogleCredential) -> AnyPublisher<User, Error> {
+        signInWithGoogleCallCount += 1
+        return signInWithGoogleResult.publisher.eraseToAnyPublisher()
+    }
+
+    func logout() -> AnyPublisher<Void, Error> {
+        logoutCallCount += 1
+        return logoutResult.publisher.eraseToAnyPublisher()
+    }
+
+    func observeAuthState() -> AnyPublisher<User?, Never> {
+        observeAuthStateCallCount += 1
+        return authStateSubject.eraseToAnyPublisher()
+    }
+
+    // MARK: - Test helpers
+
+    func sendAuthState(_ user: User?) {
+        authStateSubject.send(user)
+    }
+}

--- a/liga1Tests/Mocks/MockLogoutUseCase.swift
+++ b/liga1Tests/Mocks/MockLogoutUseCase.swift
@@ -1,0 +1,17 @@
+// MockLogoutUseCase.swift
+// liga1Tests
+
+import Combine
+import Foundation
+@testable import liga1
+
+final class MockLogoutUseCase: LogoutUseCaseProtocol {
+
+    var result: Result<Void, Error> = .success(())
+    var executeCallCount = 0
+
+    func execute() -> AnyPublisher<Void, Error> {
+        executeCallCount += 1
+        return result.publisher.eraseToAnyPublisher()
+    }
+}

--- a/liga1Tests/Mocks/MockTeamsRepository.swift
+++ b/liga1Tests/Mocks/MockTeamsRepository.swift
@@ -9,7 +9,9 @@ final class MockTeamsRepository: TeamsRepositoryProtocol {
 
     var fetchResult: Result<[Team], Error> = .success([])
     var fetchCallCount = 0
+    var invalidateCacheCallCount = 0
     var lastTorneoRequested: TorneoType?
+    var lastInvalidatedTorneo: TorneoType??   // nil = not called; .some(nil) = invalidate all
 
     func fetchTeams(for torneo: TorneoType) -> AnyPublisher<[Team], Error> {
         fetchCallCount += 1
@@ -20,5 +22,10 @@ final class MockTeamsRepository: TeamsRepositoryProtocol {
         case .failure(let error):
             return Fail(error: error).eraseToAnyPublisher()
         }
+    }
+
+    func invalidateCache(for torneo: TorneoType?) {
+        invalidateCacheCallCount += 1
+        lastInvalidatedTorneo = torneo
     }
 }

--- a/liga1Tests/Repositories/CachingTeamsRepositoryTests.swift
+++ b/liga1Tests/Repositories/CachingTeamsRepositoryTests.swift
@@ -1,0 +1,139 @@
+// CachingTeamsRepositoryTests.swift
+// liga1Tests
+
+import XCTest
+import Combine
+@testable import liga1
+
+final class CachingTeamsRepositoryTests: XCTestCase {
+
+    private var inner: MockTeamsRepository!
+    private var sut: CachingTeamsRepository!
+    private var cancellables = Set<AnyCancellable>()
+
+    override func setUp() {
+        super.setUp()
+        inner = MockTeamsRepository()
+        sut = CachingTeamsRepository(wrapping: inner)
+    }
+
+    override func tearDown() {
+        cancellables.removeAll()
+        sut = nil
+        inner = nil
+        super.tearDown()
+    }
+
+    // MARK: - Cache Miss (primera llamada)
+
+    func test_fetchTeams_firstCall_delegatesToInner() throws {
+        inner.fetchResult = .success([Team.fixture()])
+        _ = try awaitValue(from: sut.fetchTeams(for: .apertura))
+        XCTAssertEqual(inner.fetchCallCount, 1)
+    }
+
+    // MARK: - Cache Hit (segunda llamada)
+
+    func test_fetchTeams_secondCall_doesNotCallInner() throws {
+        inner.fetchResult = .success([Team.fixture()])
+        _ = try awaitValue(from: sut.fetchTeams(for: .apertura))  // populate cache
+        inner.fetchCallCount = 0                                    // reset counter
+
+        _ = try awaitValue(from: sut.fetchTeams(for: .apertura))  // should hit cache
+
+        XCTAssertEqual(inner.fetchCallCount, 0, "La segunda llamada debería resolver desde caché")
+    }
+
+    func test_fetchTeams_cacheHit_returnsCorrectTeams() throws {
+        let expected = [Team.fixture(nombre: "Alianza"), Team.fixture(nombre: "Universitario")]
+        inner.fetchResult = .success(expected)
+
+        _ = try awaitValue(from: sut.fetchTeams(for: .apertura))
+        let cached = try awaitValue(from: sut.fetchTeams(for: .apertura))
+
+        XCTAssertEqual(cached, expected)
+    }
+
+    // MARK: - Torneo isolation
+
+    func test_fetchTeams_differentTorneos_cachedSeparately() throws {
+        let aperturaTeams = [Team.fixture(nombre: "AperturaTeam")]
+        let clausuraTeams = [Team.fixture(nombre: "ClausuraTeam")]
+
+        inner.fetchResult = .success(aperturaTeams)
+        _ = try awaitValue(from: sut.fetchTeams(for: .apertura))
+
+        inner.fetchResult = .success(clausuraTeams)
+        _ = try awaitValue(from: sut.fetchTeams(for: .clausura))
+
+        inner.fetchCallCount = 0
+
+        // Both hits should come from cache
+        _ = try awaitValue(from: sut.fetchTeams(for: .apertura))
+        _ = try awaitValue(from: sut.fetchTeams(for: .clausura))
+
+        XCTAssertEqual(inner.fetchCallCount, 0)
+    }
+
+    // MARK: - invalidateCache (torneo específico)
+
+    func test_invalidateCache_specificTorneo_refetchesFromInner() throws {
+        inner.fetchResult = .success([Team.fixture()])
+        _ = try awaitValue(from: sut.fetchTeams(for: .apertura))
+
+        sut.invalidateCache(for: .apertura)
+        inner.fetchCallCount = 0
+
+        _ = try awaitValue(from: sut.fetchTeams(for: .apertura))
+
+        XCTAssertEqual(inner.fetchCallCount, 1, "Tras invalidar debería buscar en el inner repository")
+    }
+
+    func test_invalidateCache_specificTorneo_doesNotAffectOtherTorneo() throws {
+        let clausuraTeams = [Team.fixture(nombre: "ClausuraTeam")]
+        inner.fetchResult = .success(clausuraTeams)
+        _ = try awaitValue(from: sut.fetchTeams(for: .clausura))
+
+        sut.invalidateCache(for: .apertura)   // invalida solo apertura
+        inner.fetchCallCount = 0
+
+        _ = try awaitValue(from: sut.fetchTeams(for: .clausura))  // debe venir de caché
+
+        XCTAssertEqual(inner.fetchCallCount, 0, "Clausura no debería verse afectada al invalidar apertura")
+    }
+
+    // MARK: - invalidateCache (all)
+
+    func test_invalidateCache_nil_invalidatesAll() throws {
+        inner.fetchResult = .success([Team.fixture()])
+        _ = try awaitValue(from: sut.fetchTeams(for: .apertura))
+        _ = try awaitValue(from: sut.fetchTeams(for: .clausura))
+
+        sut.invalidateCache(for: nil)
+        inner.fetchCallCount = 0
+
+        _ = try awaitValue(from: sut.fetchTeams(for: .apertura))
+        _ = try awaitValue(from: sut.fetchTeams(for: .clausura))
+
+        XCTAssertEqual(inner.fetchCallCount, 2)
+    }
+
+    // MARK: - Error propagation
+
+    func test_fetchTeams_innerError_propagatesError() {
+        inner.fetchResult = .failure(TestError.network)
+        let error = try? awaitFailure(from: sut.fetchTeams(for: .apertura))
+        XCTAssertNotNil(error)
+    }
+
+    func test_fetchTeams_innerError_doesNotPopulateCache() throws {
+        inner.fetchResult = .failure(TestError.network)
+        _ = try? awaitFailure(from: sut.fetchTeams(for: .apertura))
+
+        inner.fetchResult = .success([Team.fixture()])
+        inner.fetchCallCount = 0
+        _ = try awaitValue(from: sut.fetchTeams(for: .apertura))
+
+        XCTAssertEqual(inner.fetchCallCount, 1, "Un error previo no debe dejar datos en caché")
+    }
+}

--- a/liga1Tests/UseCases/Auth/LoginWithEmailUseCaseTests.swift
+++ b/liga1Tests/UseCases/Auth/LoginWithEmailUseCaseTests.swift
@@ -1,0 +1,79 @@
+// LoginWithEmailUseCaseTests.swift
+// liga1Tests
+
+import XCTest
+import Combine
+@testable import liga1
+
+final class LoginWithEmailUseCaseTests: XCTestCase {
+
+    private var authService: MockAuthService!
+    private var sut: LoginWithEmailUseCase!
+    private var cancellables = Set<AnyCancellable>()
+
+    override func setUp() {
+        super.setUp()
+        authService = MockAuthService()
+        sut = LoginWithEmailUseCase(authService: authService)
+    }
+
+    override func tearDown() {
+        cancellables.removeAll()
+        sut = nil
+        authService = nil
+        super.tearDown()
+    }
+
+    // MARK: - Validation (auth never called)
+
+    func test_execute_emptyEmail_failsWithValidationError() {
+        let error = try? awaitFailure(from: sut.execute(email: "", password: "Pass123!"))
+        XCTAssertNotNil(error)
+        XCTAssertEqual(authService.loginCallCount, 0, "Auth nunca debería llamarse con email inválido")
+    }
+
+    func test_execute_emptyPassword_failsWithValidationError() {
+        let error = try? awaitFailure(from: sut.execute(email: "user@liga1.pe", password: ""))
+        XCTAssertNotNil(error)
+        XCTAssertEqual(authService.loginCallCount, 0)
+    }
+
+    func test_execute_invalidEmailFormat_failsWithValidationError() {
+        let error = try? awaitFailure(from: sut.execute(email: "not-an-email", password: "Pass123!"))
+        XCTAssertNotNil(error)
+        XCTAssertEqual(authService.loginCallCount, 0)
+    }
+
+    // MARK: - Delegation to auth service
+
+    func test_execute_validCredentials_callsAuthService() throws {
+        authService.loginResult = .success(.fixture())
+        _ = try awaitValue(from: sut.execute(email: "user@liga1.pe", password: "Pass123!"))
+        XCTAssertEqual(authService.loginCallCount, 1)
+    }
+
+    func test_execute_validCredentials_forwardsEmailToAuthService() throws {
+        authService.loginResult = .success(.fixture())
+        _ = try awaitValue(from: sut.execute(email: "user@liga1.pe", password: "Pass123!"))
+        XCTAssertEqual(authService.lastLoginEmail, "user@liga1.pe")
+    }
+
+    // MARK: - Success
+
+    func test_execute_success_returnsUser() throws {
+        let expected = User.fixture(email: "user@liga1.pe")
+        authService.loginResult = .success(expected)
+
+        let result = try awaitValue(from: sut.execute(email: "user@liga1.pe", password: "Pass123!"))
+        XCTAssertEqual(result, expected)
+    }
+
+    // MARK: - Auth failure
+
+    func test_execute_authFailure_propagatesError() {
+        authService.loginResult = .failure(TestError.network)
+
+        let error = try? awaitFailure(from: sut.execute(email: "user@liga1.pe", password: "Pass123!"))
+        XCTAssertNotNil(error)
+    }
+}

--- a/liga1Tests/UseCases/Auth/LogoutUseCaseTests.swift
+++ b/liga1Tests/UseCases/Auth/LogoutUseCaseTests.swift
@@ -1,0 +1,70 @@
+// LogoutUseCaseTests.swift
+// liga1Tests
+
+import XCTest
+import Combine
+@testable import liga1
+
+final class LogoutUseCaseTests: XCTestCase {
+
+    private var authService: MockAuthService!
+    private var sut: LogoutUseCase!
+    private var cancellables = Set<AnyCancellable>()
+
+    override func setUp() {
+        super.setUp()
+        authService = MockAuthService()
+        sut = LogoutUseCase(authService: authService)
+    }
+
+    override func tearDown() {
+        cancellables.removeAll()
+        sut = nil
+        authService = nil
+        super.tearDown()
+    }
+
+    // MARK: - Delegation
+
+    func test_execute_callsAuthService() throws {
+        try awaitCompletion(of: sut.execute())
+        XCTAssertEqual(authService.logoutCallCount, 1)
+    }
+
+    func test_execute_calledTwice_callsAuthServiceTwice() throws {
+        try awaitCompletion(of: sut.execute())
+        try awaitCompletion(of: sut.execute())
+        XCTAssertEqual(authService.logoutCallCount, 2)
+    }
+
+    // MARK: - Success
+
+    func test_execute_success_completesWithoutError() throws {
+        authService.logoutResult = .success(())
+        XCTAssertNoThrow(try awaitCompletion(of: sut.execute()))
+    }
+
+    // MARK: - Failure
+
+    func test_execute_failure_propagatesError() {
+        authService.logoutResult = .failure(TestError.network)
+
+        var capturedError: Error?
+        let exp = expectation(description: "error received")
+
+        sut.execute()
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let e) = completion {
+                        capturedError = e
+                        exp.fulfill()
+                    }
+                },
+                receiveValue: { }
+            )
+            .store(in: &cancellables)
+
+        waitForExpectations(timeout: 2)
+        XCTAssertTrue(capturedError is TestError)
+    }
+}

--- a/liga1Tests/ViewModels/ProfileViewModelTests.swift
+++ b/liga1Tests/ViewModels/ProfileViewModelTests.swift
@@ -1,0 +1,157 @@
+// ProfileViewModelTests.swift
+// liga1Tests
+
+import XCTest
+import Combine
+@testable import liga1
+
+final class ProfileViewModelTests: XCTestCase {
+
+    private var authService: MockAuthService!
+    private var logoutUseCase: MockLogoutUseCase!
+    private var sut: ProfileViewModel!
+    private var cancellables = Set<AnyCancellable>()
+
+    override func setUp() {
+        super.setUp()
+        authService = MockAuthService()
+        logoutUseCase = MockLogoutUseCase()
+        sut = ProfileViewModel(authService: authService, logoutUseCase: logoutUseCase)
+    }
+
+    override func tearDown() {
+        cancellables.removeAll()
+        sut = nil
+        logoutUseCase = nil
+        authService = nil
+        super.tearDown()
+    }
+
+    // MARK: - Sections setup
+
+    func test_init_setupsSections() {
+        XCTAssertFalse(sut.sections.isEmpty)
+    }
+
+    // MARK: - Auth state observation
+
+    func test_init_observesAuthState() {
+        XCTAssertEqual(authService.observeAuthStateCallCount, 1)
+    }
+
+    func test_authStateChange_updatesDisplayName() {
+        let user = User.fixture(displayName: "Miguel")
+        let exp = expectation(description: "displayName updated")
+
+        sut.$displayName
+            .dropFirst()
+            .sink { name in
+                if name == "Miguel" { exp.fulfill() }
+            }
+            .store(in: &cancellables)
+
+        authService.sendAuthState(user)
+        waitForExpectations(timeout: 2)
+        XCTAssertEqual(sut.displayName, "Miguel")
+    }
+
+    func test_authStateChange_updatesEmail() {
+        let user = User.fixture(email: "miguel@liga1.pe")
+        let exp = expectation(description: "email updated")
+
+        sut.$email
+            .dropFirst()
+            .sink { email in
+                if email == "miguel@liga1.pe" { exp.fulfill() }
+            }
+            .store(in: &cancellables)
+
+        authService.sendAuthState(user)
+        waitForExpectations(timeout: 2)
+        XCTAssertEqual(sut.email, "miguel@liga1.pe")
+    }
+
+    // MARK: - Logout - success
+
+    func test_logout_callsLogoutUseCase() {
+        sut.logout()
+        XCTAssertEqual(logoutUseCase.executeCallCount, 1)
+    }
+
+    func test_logout_success_setsLogoutSuccessful() {
+        logoutUseCase.result = .success(())
+
+        let exp = expectation(description: "logoutSuccessful becomes true")
+        sut.$logoutSuccessful
+            .dropFirst()
+            .sink { if $0 { exp.fulfill() } }
+            .store(in: &cancellables)
+
+        sut.logout()
+        waitForExpectations(timeout: 2)
+        XCTAssertTrue(sut.logoutSuccessful)
+    }
+
+    func test_logout_success_clearsError() {
+        logoutUseCase.result = .success(())
+        sut.logout()
+
+        let exp = expectation(description: "isLoading resets")
+        sut.$isLoading
+            .filter { !$0 }
+            .sink { _ in exp.fulfill() }
+            .store(in: &cancellables)
+
+        waitForExpectations(timeout: 2)
+        XCTAssertNil(sut.error)
+    }
+
+    // MARK: - Logout - failure
+
+    func test_logout_failure_doesNotSetLogoutSuccessful() {
+        logoutUseCase.result = .failure(TestError.network)
+        sut.logout()
+
+        let exp = expectation(description: "isLoading resets after failure")
+        sut.$isLoading
+            .filter { !$0 }
+            .sink { _ in exp.fulfill() }
+            .store(in: &cancellables)
+
+        waitForExpectations(timeout: 2)
+        XCTAssertFalse(sut.logoutSuccessful)
+    }
+
+    func test_logout_failure_setsError() {
+        logoutUseCase.result = .failure(TestError.network)
+
+        let exp = expectation(description: "error set")
+        sut.$error
+            .compactMap { $0 }
+            .sink { _ in exp.fulfill() }
+            .store(in: &cancellables)
+
+        sut.logout()
+        waitForExpectations(timeout: 2)
+        XCTAssertNotNil(sut.error)
+    }
+
+    // MARK: - isLoading
+
+    func test_logout_setsIsLoadingTrue_thenFalse() {
+        var loadingStates: [Bool] = []
+        let exp = expectation(description: "loading transitions captured")
+
+        sut.$isLoading
+            .dropFirst()  // skip initial false
+            .sink { state in
+                loadingStates.append(state)
+                if loadingStates.count == 2 { exp.fulfill() }
+            }
+            .store(in: &cancellables)
+
+        sut.logout()
+        waitForExpectations(timeout: 2)
+        XCTAssertEqual(loadingStates, [true, false])
+    }
+}


### PR DESCRIPTION
…orar testabilidad

- AuthServiceProtocol: elimina 11 accesos directos a AuthManager.shared (DIP)
- Auth Use Cases: LoginWithEmailUseCase, LoginWithGoogleUseCase, ObserveAuthStateUseCase
- LogoutUseCase: único punto de autoridad para logout (Command Pattern)
- InactivityManager: extrae timer de SessionManager (SRP)
- CachingTeamsRepository: mueve caché de TorneoViewModel a capa Data (Decorator)
- AppEvent: elimina .loginSuccess redundante; añade .sessionExpired
- Tests: MockAuthService, MockLogoutUseCase + 4 suites de tests (ProfileViewModel, LogoutUseCase, LoginWithEmail, CachingTeamsRepository)
- project.pbxproj: registra los 7 nuevos archivos en el target liga1